### PR TITLE
Add endpoint as configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ We will also add support for easier integration with your models, by adding a S3
             'defaultBucket' => 'my-bucket',
             'defaultAcl' => 'public-read',
             'defaultPresignedExpiration' => '+1 hour',
+            'endpoint' => 'http://localhost:9000',
         ],
         // ...
     ],
     ```
 
 **Credentials parameter is optional**: if you plan to use IAM roles attached to your EC2 instance there is no need for credentials. Just remove this parameter. Just be cautious if you need those credentials, this may cause errors during execution.
+**Endpoint parameter is optional**: You can specify a custom endpoint here. Great for debugging with minio for example.
 
 ## Basic usage
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -24,6 +24,7 @@ use yii\helpers\ArrayHelper;
  * @method bool             exist(string $filename)
  * @method string           getUrl(string $filename)
  * @method string           getPresignedUrl(string $filename, $expires)
+ * @property string         $endpoint
  *
  * @package bpsys\yii2\aws\s3
  */
@@ -157,6 +158,15 @@ class Service extends Component implements ServiceInterface
     public function setHttpOptions(array $options)
     {
         $this->clientConfig['http'] = $options;
+    }
+
+    /**
+     * @param string $endpoint
+     */
+    public function setEndpoint(string $endpoint)
+    {
+        $this->clientConfig['endpoint']                = $endpoint;
+        $this->clientConfig['use_path_style_endpoint'] = true;
     }
 
     /**


### PR DESCRIPTION
This change allows using `endpoint` in the component configuration, a suggestion which was raised in the upstream [here](https://github.com/frostealth/yii2-aws-s3/issues/37).
I need it for a own project and hope the community can use it too.